### PR TITLE
Cross build for Scala 2.13 and 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,12 +15,14 @@ lazy val root = (project in file("."))
   .settings(
     name := "redirect-resolver",
     organization := "com.gu",
+    crossScalaVersions := Seq("3.3.1", scalaVersion.value),
     Test / testOptions +=
       Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")
   )
 
 licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value
+releaseCrossBuild := true
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,

--- a/src/main/scala/com/gu/http/redirect/resolver/UrlResponseFetcher.scala
+++ b/src/main/scala/com/gu/http/redirect/resolver/UrlResponseFetcher.scala
@@ -62,7 +62,7 @@ object UrlResponseFetcher {
 
     override def fetchResponseFor(uri: URI)(implicit ec: ExecutionContext): Future[HttpResponseSummary] = for {
       response <- getHeadResponse(uri)
-    } yield HttpResponseSummary(response.statusCode, response.headers().firstValue("Location").toScala.map(LocationHeader))
+    } yield HttpResponseSummary(response.statusCode, response.headers().firstValue("Location").toScala.map(LocationHeader.apply))
   }
 }
 


### PR DESCRIPTION
## What does this change?
It adds the ability to cross build the library in both Scala 2.13 and 3.

## Why?
We need this because `google-search-indexing-observatory` uses 3.
