### PR TITLE
Handle exceptions as result values & model `FollowResult`

### DIFF
--- a/src/main/scala/com/gu/http/redirect/resolver/FollowResult.scala
+++ b/src/main/scala/com/gu/http/redirect/resolver/FollowResult.scala
@@ -1,7 +1,7 @@
 package com.gu.http.redirect.resolver
 
 import java.net.URI
-import scala.util.Try
+import scala.util.{Success, Try}
 
 /**
  * The result of following a url once - could either be a redirect, or some kind of conclusion.
@@ -13,4 +13,12 @@ case class Redirect(uri: URI) extends FollowResult
 /**
  * Could be DNS or Network failure, or a successful HTTP status code.
  */
-case class Conclusion(statusCode: Try[Int]) extends FollowResult
+case class Conclusion(statusCode: Try[Int]) extends FollowResult {
+
+  val isOk: Boolean = statusCode.toOption.contains(200)
+}
+
+object Conclusion {
+  val Ok: Conclusion = Conclusion(Success(200))
+}
+

--- a/src/main/scala/com/gu/http/redirect/resolver/FollowResult.scala
+++ b/src/main/scala/com/gu/http/redirect/resolver/FollowResult.scala
@@ -1,0 +1,16 @@
+package com.gu.http.redirect.resolver
+
+import java.net.URI
+import scala.util.Try
+
+/**
+ * The result of following a url once - could either be a redirect, or some kind of conclusion.
+ */
+sealed trait FollowResult
+
+case class Redirect(uri: URI) extends FollowResult
+
+/**
+ * Could be DNS or Network failure, or a successful HTTP status code.
+ */
+case class Conclusion(statusCode: Try[Int]) extends FollowResult

--- a/src/main/scala/com/gu/http/redirect/resolver/UrlResolver.scala
+++ b/src/main/scala/com/gu/http/redirect/resolver/UrlResolver.scala
@@ -2,53 +2,43 @@ package com.gu.http.redirect.resolver
 
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import com.gu.http.redirect.resolver.Resolution.{Resolved, Unresolved}
-import com.gu.http.redirect.resolver.UrlResolver.{Conclusion, Redirect}
 
 import java.net.URI
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.Failure
 
 sealed trait Resolution {
   val redirectPath: RedirectPath
 }
 
 object Resolution {
-  case class Resolved(redirectPath: RedirectPath, statusCode: Try[Int]) extends Resolution
+  case class Resolved(redirectPath: RedirectPath, conclusion: Conclusion) extends Resolution
 
   case class Unresolved(redirectPath: RedirectPath) extends Resolution
 }
 
-object UrlResolver {
-  type Conclusion = Try[Int]
-  type Redirect = URI
-}
-
 class UrlResolver(fetcher: UrlResponseFetcher, maxRedirects: Int = 10) {
 
-  val cache: AsyncLoadingCache[URI, Either[Redirect, Conclusion]] =
+  val cache: AsyncLoadingCache[URI, FollowResult] =
     Scaffeine()
       .recordStats()
       .expireAfterWrite(10.minutes)
       .maximumSize(500)
       .buildAsyncFuture(followOnce)
 
-  private def followOnce(uri: URI): Future[Either[Redirect, Conclusion]] = {
-    fetcher.fetchResponseFor(uri).transform {
-      case Success(summary) =>
-        Success(summary.absoluteRedirectRelativeTo(uri).toLeft(Success(summary.statusCode)))
-      case Failure(exception) =>
-        Success(Right(Failure(exception)))
+  private def followOnce(uri: URI): Future[FollowResult] =
+    fetcher.fetchResponseFor(uri).map(_.asFollowResultGiven(uri)).recover {
+      case exception => Conclusion(Failure(exception))
     }
-  }
 
   def resolve(uri: URI): Future[Resolution] = resolveFollowing(RedirectPath(uri))
 
   private def resolveFollowing(redirectPath: RedirectPath): Future[Resolution] =
     if (redirectPath.numRedirects >= maxRedirects || redirectPath.isLoop) Future.successful(Unresolved(redirectPath))
-    else cache.get(redirectPath.latestUri).flatMap { _.fold(
-      subsequentUri => resolveFollowing(redirectPath.adding(subsequentUri)),
-      tryFinalStatusCode => Future.successful(Resolved(redirectPath, tryFinalStatusCode))
-    )}
+    else cache.get(redirectPath.latestUri).flatMap {
+      case Redirect(subsequentUri) => resolveFollowing(redirectPath.adding(subsequentUri))
+      case conclusion: Conclusion => Future.successful(Resolved(redirectPath, conclusion))
+    }
 }

--- a/src/main/scala/com/gu/http/redirect/resolver/UrlResolver.scala
+++ b/src/main/scala/com/gu/http/redirect/resolver/UrlResolver.scala
@@ -2,33 +2,46 @@ package com.gu.http.redirect.resolver
 
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import com.gu.http.redirect.resolver.Resolution.{Resolved, Unresolved}
+import com.gu.http.redirect.resolver.UrlResolver.{Conclusion, Redirect}
 
 import java.net.URI
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
 
 sealed trait Resolution {
   val redirectPath: RedirectPath
 }
 
 object Resolution {
-  case class Resolved(redirectPath: RedirectPath, statusCode: Int) extends Resolution
+  case class Resolved(redirectPath: RedirectPath, statusCode: Try[Int]) extends Resolution
 
   case class Unresolved(redirectPath: RedirectPath) extends Resolution
 }
 
+object UrlResolver {
+  type Conclusion = Try[Int]
+  type Redirect = URI
+}
+
 class UrlResolver(fetcher: UrlResponseFetcher, maxRedirects: Int = 10) {
 
-  val cache: AsyncLoadingCache[URI, Either[URI, Int]] =
+  val cache: AsyncLoadingCache[URI, Either[Redirect, Conclusion]] =
     Scaffeine()
       .recordStats()
       .expireAfterWrite(10.minutes)
       .maximumSize(500)
       .buildAsyncFuture(followOnce)
 
-  private def followOnce(uri: URI): Future[Either[URI, Int]] =
-    fetcher.fetchResponseFor(uri).map(summary => summary.absoluteRedirectRelativeTo(uri).toLeft(summary.statusCode))
+  private def followOnce(uri: URI): Future[Either[Redirect, Conclusion]] = {
+    fetcher.fetchResponseFor(uri).transform {
+      case Success(summary) =>
+        Success(summary.absoluteRedirectRelativeTo(uri).toLeft(Success(summary.statusCode)))
+      case Failure(exception) =>
+        Success(Right(Failure(exception)))
+    }
+  }
 
   def resolve(uri: URI): Future[Resolution] = resolveFollowing(RedirectPath(uri))
 
@@ -36,6 +49,6 @@ class UrlResolver(fetcher: UrlResponseFetcher, maxRedirects: Int = 10) {
     if (redirectPath.numRedirects >= maxRedirects || redirectPath.isLoop) Future.successful(Unresolved(redirectPath))
     else cache.get(redirectPath.latestUri).flatMap { _.fold(
       subsequentUri => resolveFollowing(redirectPath.adding(subsequentUri)),
-      finalStatusCode => Future.successful(Resolved(redirectPath, finalStatusCode))
+      tryFinalStatusCode => Future.successful(Resolved(redirectPath, tryFinalStatusCode))
     )}
 }

--- a/src/test/scala/com/gu/http/redirect/resolver/UrlResolverTest.scala
+++ b/src/test/scala/com/gu/http/redirect/resolver/UrlResolverTest.scala
@@ -1,23 +1,36 @@
 package com.gu.http.redirect.resolver
 
 import com.gu.http.redirect.resolver.Resolution.Resolved
-import com.gu.http.redirect.resolver.UrlResponseFetcher.javaNetHttpFollower
+import com.gu.http.redirect.resolver.UrlResponseFetcher.JavaNetHttpResponseFetcher
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.net.URI
+import scala.util.Success
 
 class UrlResolverTest extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationPatience with EitherValues {
   it should "resolve a BBC url" in {
-    val urlResolver = new UrlResolver(javaNetHttpFollower)
+    val urlResolver = new UrlResolver(JavaNetHttpResponseFetcher)
     whenReady(
       urlResolver.resolve(URI.create("https://www.bbc.co.uk/news/uk-politics-63534039"))
     ){
       resolution => resolution shouldBe
         Resolved(RedirectPath(Seq(URI.create("https://www.bbc.co.uk/news/uk-politics-63534039"),
-          URI.create("https://www.bbc.co.uk/news/av/uk-politics-63534039"))), 200)
+          URI.create("https://www.bbc.co.uk/news/av/uk-politics-63534039"))), Conclusion(Success(200)))
+    }
+  }
+
+  it should "not crash for domains that do not exist" in {
+    val uriWithNonExistentDomain = URI.create("https://www.doesnotexist12312312234523532534546.com/")
+    val urlResolver = new UrlResolver(JavaNetHttpResponseFetcher)
+
+    whenReady(
+      urlResolver.resolve(uriWithNonExistentDomain)
+    ){
+      resolution =>
+        resolution.redirectPath shouldBe RedirectPath(Seq(uriWithNonExistentDomain))
     }
   }
 }

--- a/src/test/scala/com/gu/http/redirect/resolver/UrlResponseFetcherTest.scala
+++ b/src/test/scala/com/gu/http/redirect/resolver/UrlResponseFetcherTest.scala
@@ -1,7 +1,7 @@
 package com.gu.http.redirect.resolver
 
 import com.gu.http.redirect.resolver.UrlResponseFetcher.HttpResponseSummary.LocationHeader
-import com.gu.http.redirect.resolver.UrlResponseFetcher.javaNetHttpFollower
+import com.gu.http.redirect.resolver.UrlResponseFetcher.JavaNetHttpResponseFetcher
 import org.scalatest.{EitherValues, OptionValues}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class UrlResponseFetcherTest extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationPatience with OptionValues {
   it should "resolve a BBC url" in {
     whenReady(
-      javaNetHttpFollower.fetchResponseFor(URI.create("https://www.bbc.co.uk/news/uk-politics-63534039"))
+      JavaNetHttpResponseFetcher.fetchResponseFor(URI.create("https://www.bbc.co.uk/news/uk-politics-63534039"))
     ){
       maybeUri => maybeUri.maybeLocationHeader.value shouldBe LocationHeader("/news/av/uk-politics-63534039")
     }


### PR DESCRIPTION
When we applied our library in https://github.com/guardian/google-search-indexing-observatory/pull/50, we saw [a test failure](https://github.com/guardian/google-search-indexing-observatory/actions/runs/8019849747/job/21908455409?pr=50#step:6:102) because our library didn't handle/wrap some exceptional circumstances (eg DNS lookup failure, network timeout, all that kind of stuff) - instead our library would just allow the exception to be thrown upwards into the calling code.

