### PR TITLE
Try out `.tool-versions` support in `gha-scala-library-release-workflow`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@use-java-version-specified-by-tool-versions-for-project-build
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+lava corretto-21.0.3.9.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-lava corretto-21.0.3.9.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-21.0.3.9.1


### PR DESCRIPTION
https://github.com/guardian/gha-scala-library-release-workflow/pull/36