### PR TITLE
Fix for missing sbt by using new `guardian/setup-scala` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup JDK
-        uses: rtyley/setup-java@patch-1
-        with:
-          distribution: corretto
-          java-version: 17 # Currently Java 17 required by `s3mock-testcontainers`
-          cache: sbt
+      - uses: guardian/setup-scala@v1
       - name: Build and Test
         run: sbt -v +test
       - name: Test Summary


### PR DESCRIPTION
Using the new GitHub Action [`guardian/setup-scala`](https://github.com/guardian/setup-scala/) to cope with `sbt` being removed from the latest Ubuntu images we use for CI. This composite action combines [`setup-java`](https://github.com/actions/setup-java) and [`setup-sbt`](https://github.com/sbt/setup-sbt) with good defaults for the Guardian.

#### Version of Java used by CI now specified by `.tool-versions` file

Note that (like [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow/pull/36)) `guardian/setup-scala` requires that projects specify their Java version with an [`asdf`](https://asdf-vm.com/)-formatted `.tool-versions` file - we didn't have to _add_ one with this PR, as we already added it for `gha-scala-library-release-workflow` with 3ec016ea807c0dabc69d14299fbd0b421ee2028b.