### PR TITLE
Update to `gha-scala-library-release-workflow` v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v1
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v2
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,9 @@
 import sbtrelease.ReleaseStateTransformations._
-import sbtversionpolicy.withsbtrelease.ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 ThisBuild / scalaVersion := "2.13.16"
 
-resolvers ++= Resolver.sonatypeOssRepos("public")
-
-libraryDependencies ++= List(
+libraryDependencies ++= Seq(
   "com.github.blemale" %% "scaffeine" % "5.3.0",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "org.http4s" %% "http4s-blaze-server" % "0.23.17" % Test,
@@ -22,8 +20,8 @@ lazy val root = (project in file("."))
       Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")
   )
 
-licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value
+licenses := Seq(License.Apache2)
+releaseVersion := ReleaseVersion.fromAssessedCompatibilityWithLatestRelease().value
 releaseCrossBuild := true
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")


### PR DESCRIPTION
See:

* https://github.com/guardian/gha-scala-library-release-workflow/releases/tag/v2.0.0
* https://github.com/guardian/gha-scala-library-release-workflow/pull/62